### PR TITLE
fix: skip import if transactions already exist

### DIFF
--- a/backend/logs/processing-stats.json
+++ b/backend/logs/processing-stats.json
@@ -2,5 +2,5 @@
   "processed": 1682,
   "ignored": 9,
   "total": 1691,
-  "timestamp": "2025-06-15T19:38:11.211Z"
+  "timestamp": "2025-06-16T16:06:16.516Z"
 }

--- a/backend/src/dataProcessor.mjs
+++ b/backend/src/dataProcessor.mjs
@@ -207,6 +207,21 @@ class DataProcessor {
 
   async processXMLFile(filePath) {
     try {
+
+          // First check if the table has any rows
+        const checkResult = await pool.query('SELECT COUNT(*) FROM transactions');
+        const rowCount = parseInt(checkResult.rows[0].count);
+        
+        if (rowCount > 0) {
+            console.log('Database already contains transactions. Skipping import.');
+            return {
+                processed: 0,
+                ignored: 0,
+                total: 0,
+                message: 'Database already contains transactions. Import skipped.'
+            };
+        }
+
       // Read and parse XML file
       const xmlData = fs.readFileSync(filePath, 'utf8');
       const parser = new xml2js.Parser({ explicitArray: false });

--- a/backend/utils/importData.mjs
+++ b/backend/utils/importData.mjs
@@ -1,4 +1,4 @@
-import { DataProcessor } from './dataProcessor.mjs';
+import { DataProcessor } from '../src/dataProcessor.mjs'; // relative path  the module
 import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';


### PR DESCRIPTION
- Added pre-check to skip entire import if transactions table is not empty
- Prevents duplicate entries when re-running the processor